### PR TITLE
Update licenses

### DIFF
--- a/circuitpython_functools.py
+++ b/circuitpython_functools.py
@@ -1,8 +1,10 @@
 # SPDX-FileCopyrightText: 2017 Scott Shawcroft, written for Adafruit Industries
 # SPDX-FileCopyrightText: Copyright (c) 2022 Alec Delaney
+# SPDX-FileCopyrightText: Python Software Foundation
 # SPDX-FileCopyrightText: MicroPython Developers
 #
 # SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: PSF-2.0
 
 """
 `circuitpython_functools`
@@ -38,6 +40,7 @@ class _ObjectMark:
     pass
 
 
+# Cache-related functions ported from CPython
 def _make_key(args, kwargs, kwd_mark=(_ObjectMark(),)):
     key = tuple(args)
     if kwargs:


### PR DESCRIPTION
Now includes PSF-2.0 license for cache-related code ported from CPython